### PR TITLE
Nitpick: announce waits *before* the wait starts

### DIFF
--- a/scripts/bootstrap_arm.sh
+++ b/scripts/bootstrap_arm.sh
@@ -119,9 +119,8 @@ chown $(id -u):$(id -g) /root/.kube/config
 export KUBECONFIG=/root/.kube/config
 
 until kubectl get po --all-namespaces
-do
-  sleep 5
-  echo "Waiting...."
+do echo "($0:$LINENO) Waiting..."
+   sleep 5
 done
 
 kubectl taint nodes $(hostname -s) node-role.kubernetes.io/master:NoSchedule-


### PR DESCRIPTION
Also, let the user know where to look in the code if the wait gets stuck in an infinite loop.